### PR TITLE
fix: Update Slack notification workflow reference to use main branch

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   notify:
-    uses: subhamay-bhattacharyya-gha/slack-notification-wf/.github/workflows/slack-notify.yaml@feature/GHA-0002-initial-release
+    uses: subhamay-bhattacharyya-gha/slack-notification-wf/.github/workflows/slack-notify.yaml@main
     secrets:
       slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request updates the Slack notification workflow configuration in `.github/workflows/notify.yaml` to use the latest version from the `main` branch instead of the `feature/GHA-0002-initial-release` branch.

* [`.github/workflows/notify.yaml`](diffhunk://#diff-0585fd55e01de551597c159b1b06185f08602999ee2aea9097bff136ceb70fe7L12-R12): Changed the `uses` directive to reference the `main` branch for the Slack notification workflow, ensuring the workflow uses the latest stable version.