### PR TITLE
fix: Update S3 bucket name for consistency

### DIFF
--- a/cfn/params/default.json
+++ b/cfn/params/default.json
@@ -1,3 +1,3 @@
 {
-    "BucketName": "subhamay-github-action-template-bucket-06611-67"
+    "BucketName": "subhamay-github-action-template-bucket-06611-68"
 }


### PR DESCRIPTION
This pull request makes a minor update to the CloudFormation default parameters by changing the value of the `BucketName` parameter. 

- Updated the `BucketName` in `cfn/params/default.json` to a new value.