### PR TITLE
fix: Update S3 bucket name and adjust permissions in workflow

### DIFF
--- a/.github/workflows/merge-pr.yaml
+++ b/.github/workflows/merge-pr.yaml
@@ -25,7 +25,7 @@ on:
 permissions:
   contents: write
   id-token: write
-  actions: read
+  # actions: read
 
 
 jobs:

--- a/cfn/params/default.json
+++ b/cfn/params/default.json
@@ -1,3 +1,3 @@
 {
-    "BucketName": "subhamay-github-action-template-bucket-06611-68"
+    "BucketName": "subhamay-github-action-template-bucket-06611-69"
 }


### PR DESCRIPTION
This pull request contains minor updates to configuration files. The changes include commenting out an unused permission in a GitHub Actions workflow and updating the default S3 bucket name in a CloudFormation parameters file.

- Workflow configuration:
  * Commented out the `actions: read` permission in `.github/workflows/merge-pr.yaml` as it is not currently needed.

- CloudFormation parameters:
  * Updated the `BucketName` value in `cfn/params/default.json` to use a new S3 bucket name.