### PR TITLE
fix: Update S3 bucket name to correct version

### DIFF
--- a/cfn/params/default.json
+++ b/cfn/params/default.json
@@ -1,3 +1,3 @@
 {
-    "BucketName": "subhamay-github-action-template-bucket-06611-69"
+    "BucketName": "subhamay-github-action-template-bucket-06611-70"
 }


### PR DESCRIPTION
This pull request includes a minor update to the default CloudFormation parameters, specifically updating the S3 bucket name.

* Changed the `BucketName` value in `cfn/params/default.json` to use a new bucket name.