### PR TITLE
fix: Update S3 bucket name to correct version

### DIFF
--- a/cfn/params/default.json
+++ b/cfn/params/default.json
@@ -1,3 +1,3 @@
 {
-    "BucketName": "subhamay-github-action-template-bucket-06611-70"
+    "BucketName": "subhamay-github-action-template-bucket-06611-71"
 }


### PR DESCRIPTION
This pull request makes a minor update to the default CloudFormation parameters by changing the `BucketName` value. This is a straightforward update and does not affect any logic or functionality.